### PR TITLE
observe beacons using distinctUntilChanged

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivebeacons/library/ReactiveBeacons.java
+++ b/library/src/main/java/com/github/pwittchen/reactivebeacons/library/ReactiveBeacons.java
@@ -76,7 +76,7 @@ public class ReactiveBeacons {
     leScanCallbackAdapter = new LeScanCallbackAdapter();
     bluetoothAdapter.startLeScan(leScanCallbackAdapter);
 
-    return leScanCallbackAdapter.toObservable().repeat().distinct().doOnUnsubscribe(new Action0() {
+    return leScanCallbackAdapter.toObservable().repeat().distinctUntilChanged().doOnUnsubscribe(new Action0() {
       @Override public void call() {
         bluetoothAdapter.stopLeScan(leScanCallbackAdapter);
       }


### PR DESCRIPTION
ReactiveBeacons.observe() used distinct operator which prevented beacon
events from being emitted if the beacon's Rssi was equal to a previously
emitted beacon's Rssi level.

The intended behaviour is to mask consecutive, duplicate beacon events from
being emitted, which can be achieved with distinctUntilChanged.