### PR TITLE
These should use an "at least one" instead of "every" pattern.

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivebeacons/library/Filter.java
+++ b/library/src/main/java/com/github/pwittchen/reactivebeacons/library/Filter.java
@@ -27,13 +27,13 @@ public class Filter {
   public static Func1<Beacon, Boolean> proximityIsEqualTo(final Proximity... proximities) {
     return new Func1<Beacon, Boolean>() {
       @Override public Boolean call(Beacon beacon) {
-        boolean proximitiesAreEqual = false;
-
         for (Proximity proximity : proximities) {
-          proximitiesAreEqual = beacon.getProximity() == proximity;
+          if (beacon.getProximity() == proximity) {
+            return true;
+          }
         }
 
-        return proximitiesAreEqual;
+        return false;
       }
     };
   }
@@ -41,13 +41,13 @@ public class Filter {
   public static Func1<Beacon, Boolean> proximityIsNotEqualTo(final Proximity... proximities) {
     return new Func1<Beacon, Boolean>() {
       @Override public Boolean call(Beacon beacon) {
-        boolean proximitiesAreEqual = false;
-
         for (Proximity proximity : proximities) {
-          proximitiesAreEqual = beacon.getProximity() != proximity;
+          if (beacon.getProximity() != proximity) {
+            return true;
+          }
         }
 
-        return proximitiesAreEqual;
+        return false;
       }
     };
   }
@@ -79,13 +79,13 @@ public class Filter {
   public static Func1<Beacon, Boolean> hasName(final String... names) {
     return new Func1<Beacon, Boolean>() {
       @Override public Boolean call(Beacon beacon) {
-        boolean namesAreEqual = false;
-
         for (String name : names) {
-          namesAreEqual = beacon.device.getName().equals(name);
+          if (beacon.device.getName().equals(name)) {
+            return true;
+          }
         }
 
-        return namesAreEqual;
+        return false;
       }
     };
   }
@@ -93,13 +93,13 @@ public class Filter {
   public static Func1<Beacon, Boolean> hasMacAddress(final String... macs) {
     return new Func1<Beacon, Boolean>() {
       @Override public Boolean call(Beacon beacon) {
-        boolean macsAreEqual = false;
-
         for (String mac : macs) {
-          macsAreEqual = beacon.device.getAddress().equals(mac);
+          if(beacon.device.getAddress().equals(mac)) {
+            return true;
+          }
         }
 
-        return macsAreEqual;
+        return false;
       }
     };
   }


### PR DESCRIPTION
Your library accepts multiple items for these filters, but the way it's programmed, every single passed item must satisfy the condition for instance, if I have:



        subscription = reactiveBeacons.observe()
                .subscribeOn(Schedulers.io())
                .observeOn(AndroidSchedulers.mainThread())
                .filter(Filter.hasMacAddress("FE:3E:AA:29:DA:05","3A:2E:7F:31:BB:BA"))



It will only trigger for devices with a mac address of "3A:2E:7F:31:BB:BA" with the current code, my pull request will make it trigger on both FE:3E:AA:29:DA:05 and 3A:2E:7F:31:BB:BA as I believe was rightfully intended.