### PR TITLE
wrapping BluetoothManager inside isBleSupported() avoids NoClassDefFoundError

### DIFF
--- a/library/src/main/java/com/github/pwittchen/reactivebeacons/library/ReactiveBeacons.java
+++ b/library/src/main/java/com/github/pwittchen/reactivebeacons/library/ReactiveBeacons.java
@@ -39,9 +39,9 @@ public class ReactiveBeacons {
    */
   @SuppressLint("NewApi") public ReactiveBeacons(Context context) {
     String bluetoothService = Context.BLUETOOTH_SERVICE;
-    BluetoothManager manager = (BluetoothManager) context.getSystemService(bluetoothService);
 
     if (isBleSupported()) {
+      BluetoothManager manager = (BluetoothManager) context.getSystemService(bluetoothService);
       bluetoothAdapter = manager.getAdapter();
       accessRequester = new AccessRequester(bluetoothAdapter);
     }


### PR DESCRIPTION
When instantiating ReactiveBeacons on devices running API < 18 a
java.lang.NoClassDefFoundError is thrown for BluetoothManager.